### PR TITLE
Added logic to inject securityDefinitions to spec.

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -4,7 +4,7 @@ set -e
 # Automated client updater.
 
 # Usage ./update.sh [swagger codegen git ref]
-# Requirements: Docker.
+# Requirements: Docker, jq.
 
 # Clone swager codegen repo.
 git clone git@github.com:swagger-api/swagger-codegen.git
@@ -12,6 +12,39 @@ cd swagger-codegen
 
 # Switch to correct branch.
 git checkout ${1:-2.3.0}
+
+# Fetch OpenShift OpenAPI spec.
+curl -Ls https://raw.githubusercontent.com/openshift/origin/master/api/swagger-spec/openshift-openapi-spec.json > openshift-openapi-spec.json
+
+# If not set, add securityDefinitions to spec.
+# @see https://github.com/openshift/origin/issues/14268
+if ! grep -q securityDefinitions openshift-openapi-spec.json; then
+    tee security-definitions.json > /dev/null <<EOF
+{
+    "securityDefinitions": {
+        "openshift_auth": {
+            "type": "oauth2",
+            "authorizationUrl": "http://localhost/oauth/authorize",
+            "flow": "implicit",
+            "scopes": {
+                "write:openshift": "modify",
+                "read:openshift": "read"
+            }
+        }
+    },
+    "security": [
+        {
+            "openshift_auth": [
+                "write:openshift",
+                "read:openshift"
+            ]
+        }
+    ]
+}
+EOF
+    mv openshift-openapi-spec.json openshift-openapi-spec-original.json
+    jq -s add openshift-openapi-spec-original.json security-definitions.json > openshift-openapi-spec.json
+fi
 
 # Put config in repo root dir.
 tee config.json > /dev/null <<EOF
@@ -27,7 +60,7 @@ EOF
 # Run swagger codegen generate.
 ./run-in-docker.sh generate \
   -l php \
-  -i https://github.com/openshift/origin/raw/master/api/swagger-spec/openshift-openapi-spec.json \
+  -i /gen/openshift-openapi-spec.json \
   -D packagePath=openshift-restclient-php \
   -c /gen/config.json \
   -o /gen/out


### PR DESCRIPTION
Added some logic to inject a simplified `securityDefinitions` item into the OpenShift OpenAPI spec. This uses a neat tool called `jq` which is like sed for json.

The resultant client generated from this change has all of the OAuth token parsing in it.